### PR TITLE
updated winstate to latest on wiki

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-'use strict';
+'use strict'
 /**
  * Cross-platform window state preservation.
  * Yes this code is quite complicated, but this is the best I came up with for
@@ -34,11 +34,7 @@ var isMaximizationEvent = false;
 // extra height added in linux x64 gnome-shell env, use it as workaround
 var deltaHeight = (function () {
     // use deltaHeight only in windows with frame enabled
-    if (gui.App.manifest.window && gui.App.manifest.window.frame) {
-        return true;
-    } else {
-        return 'disabled';
-    }
+    if (gui.App.manifest.window.frame) return true; else return 'disabled';
 })();
 
 
@@ -54,9 +50,7 @@ function initWindowState() {
         }
     } else {
         currWinMode = 'normal';
-        if (deltaHeight !== 'disabled') {
-            deltaHeight = 0;
-        }
+        if (deltaHeight !== 'disabled') deltaHeight = 0;
         dumpWindowState();
     }
 
@@ -103,7 +97,7 @@ function restoreWindowState() {
 
 function saveWindowState() {
     dumpWindowState();
-    localStorage['windowState'] = JSON.stringify(winState);
+       localStorage['windowState'] = JSON.stringify(winState);
 }
 
 initWindowState();
@@ -158,6 +152,10 @@ win.window.addEventListener('resize', function () {
 }, false);
 
 win.on('close', function () {
-    saveWindowState();
+    try {
+        saveWindowState();
+    } catch(err) {
+        console.log("winstateError: " + err);
+    }
     this.close(true);
 });

--- a/package.json
+++ b/package.json
@@ -11,7 +11,13 @@
     "node-webkit"
   ],
   "main": "index.js",
-  "scripts": {},
+  "scripts": {
+    "test": "mocha"
+  },
   "author": "azu",
-  "license": "MIT"
+  "license": "MIT",
+  "devDependencies": {
+    "mocha": "^2.1.0",
+    "proxyquire": "^1.3.2"
+  }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -40,7 +40,7 @@ proxyquire('..', {
     Window: {
       get: function() { return win; }
     },
-    App: { manifest: {} }
+    App: { manifest: { window: {} } }
   }
 });
 
@@ -97,5 +97,23 @@ describe('node-webkit-winstate', function() {
     assert(windowState.y, y);
     assert(windowState.width, width);
     assert(windowState.height, height);
+  });
+
+  it('doesnt throw if localStorage disappears on close', function() {
+    var x = 5;
+    var y = 6;
+    var width = 7;
+    var height = 8;
+
+    win.x = x;
+    win.y = y;
+    win.width = width;
+    win.height = height;
+
+    GLOBAL.localStorage = null;
+
+    assert.doesNotThrow(function() {
+      win.emit('close');
+    });
   });
 });

--- a/test/index.js
+++ b/test/index.js
@@ -1,0 +1,101 @@
+/* jshint node:true, unused:strict */
+/* global describe:true, it:true, beforeEach:true */
+
+"use strict";
+
+var proxyquire = require('proxyquire');
+var EventEmitter = require('events').EventEmitter;
+var util = require('util');
+var assert = require('assert');
+
+var START_X = 1;
+var START_Y = 2;
+var START_WIDTH = 3;
+var START_HEIGHT = 4;
+
+var WinStub = function() {
+  this.window = { addEventListener: function() {} };
+};
+util.inherits(WinStub, EventEmitter);
+WinStub.prototype.show = function() {};
+WinStub.prototype.resizeTo = function() {};
+WinStub.prototype.moveTo = function() {};
+WinStub.prototype.close = function() {};
+
+GLOBAL.localStorage = {
+  windowState: JSON.stringify({
+    x: START_X,
+    y: START_Y,
+    width: START_WIDTH,
+    height: START_HEIGHT
+  })
+};
+
+var win = new WinStub();
+
+proxyquire('..', {
+  'nw.gui': {
+    // stop proxyquire trying to load nw.gui
+    '@noCallThru': true,
+    Window: {
+      get: function() { return win; }
+    },
+    App: { manifest: {} }
+  }
+});
+
+
+describe('node-webkit-winstate', function() {
+
+  beforeEach(function() {
+    win.resizeTo = function() {};
+    win.moveTo = function() {};
+    win.x = START_X;
+    win.y = START_Y;
+    win.width = START_WIDTH;
+    win.height = START_HEIGHT;
+  });
+
+  it('restores window size on unmaximize', function(done) {
+    win.resizeTo = function(width, height) {
+      assert.equal(width, START_WIDTH);
+      assert.equal(height, START_HEIGHT);
+
+      done();
+    };
+
+    win.emit('unmaximize');
+  });
+
+  it('restores window position on unmaximize', function(done) {
+    win.moveTo = function(x, y) {
+      assert.equal(x, START_X);
+      assert.equal(y, START_Y);
+
+      done();
+    };
+
+    win.emit('unmaximize');
+  });
+
+  it('saves window state on close', function() {
+    var x = 5;
+    var y = 6;
+    var width = 7;
+    var height = 8;
+
+    win.x = x;
+    win.y = y;
+    win.width = width;
+    win.height = height;
+
+    win.emit('close');
+
+    var windowState = JSON.parse(GLOBAL.localStorage['windowState']);
+
+    assert(windowState.x, x);
+    assert(windowState.y, y);
+    assert(windowState.width, width);
+    assert(windowState.height, height);
+  });
+});


### PR DESCRIPTION
This is a copy and paste from the updated nwjs wiki page: https://github.com/nwjs/nw.js/wiki/Preserve-window-state-between-sessions

This is needed to fix some crashes when win.on('close') is called and the localStorage is missing (see https://github.com/gitterHQ/desktop/issues/35).

I've also added some tests.
